### PR TITLE
10/14/2016

### DIFF
--- a/src/mesa/drivers/dri/i915/intel_screen.h
+++ b/src/mesa/drivers/dri/i915/intel_screen.h
@@ -156,6 +156,7 @@ struct intel_screen
 #define intel_get_rb_region                 old_intel_get_rb_region
 #define intel_renderbuffer_set_draw_offset  old_intel_renderbuffer_set_draw_offset
 #define intel_miptree_create_for_image_buffer old_intel_miptree_create_for_image_buffer
+#define intelFenceExtension                 old_intelFenceExtension
 
 extern void intelDestroyContext(__DRIcontext * driContextPriv);
 


### PR DESCRIPTION
Due to conflicting symbol names (between i915 and i965) in the
megadriver, we use a set of defines in i915/intel_screen.h.

With a recent commit we've introduced a symbol intelFenceExtension which
has different implementation for each driver, yet we forgot to add the
define.

Fixes: d11515ff1b3 ("i915/sync: Implement DRI2_Fence extension")
Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=98264
Signed-off-by: Emil Velikov <emil.velikov@collabora.com>